### PR TITLE
Add macOS FFmpeg troubleshooting instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ coverage.xml
 # Environment variables
 .env
 .env.local
+
+# others 
+assets/ffmpeg/bin/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ winget install FFmpeg
 ```bash
 brew install ffmpeg
 ```
-
 **Linux:**
 ```bash
 sudo apt install ffmpeg  # Debian/Ubuntu
@@ -174,6 +173,30 @@ Downloader/
 **Решение:**
 1. Установите Deno (см. раздел "Требования")
 2. Перезапустите приложение
+
+### При запуске появляется ошибка `FFmpeg не найден. Убедитесь, что он находится в папке assets/ffmpeg/bin/ffmpeg`
+
+**Решение:**
+
+1. Создайте нужную папку в проекте:
+
+```bash
+mkdir -p assets/ffmpeg/bin
+```
+
+2. Скопируйте FFmpeg в эту папку:
+
+```bash
+cp $(which ffmpeg) assets/ffmpeg/bin/ffmpeg
+```
+
+3. Сделайте бинарник исполняемым:
+
+```bash
+chmod +x assets/ffmpeg/bin/ffmpeg
+```
+
+После этого приложение должно запускаться без ошибки.
 
 ## Автор
 


### PR DESCRIPTION
Добавлена инструкция для macOS: что делать, если при запуске появляется ошибка 'FFmpeg не найден'. 
Объясняется, как создать папку assets/ffmpeg/bin и положить туда локальный ffmpeg.